### PR TITLE
Drop timestamps from example DVI files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+LATEX = latex --output-comment=""
+
 # Nothing to be done for target 'all'.
 all: demo.dvi eksempel.dvi
 
@@ -9,13 +11,13 @@ clean:
 tests: ekempel.dvi
 
 eksempel.dvi: eksempel.tex brev.cls
-	latex eksempel
+	$(LATEX) eksempel
 
 demo.dvi: demo.tex brev.cls
-	latex demo
+	$(LATEX) demo
 
 giro.dvi: giro.tex giro.cls
-	latex giro
+	$(LATEX) giro
 
 debs:
 	fakeroot debian/rules binary


### PR DESCRIPTION
By default latex add build time stamps into the generated DVI files.
Drop these using --output-comment="" to make sure the generated DVI
files are bit-by-bit identical every build.

Patch from Debian packaging.